### PR TITLE
Doppio

### DIFF
--- a/aca-framework/app/Main.hs
+++ b/aca-framework/app/Main.hs
@@ -121,7 +121,7 @@ configuration = Configuration
       (  long "dse"
       <> showDefault
       <> metavar "TOOL"
-      <> value "cpa"
+      <> value "civl"
       <> help "who runs directed sym-exec to collect condition (civl | cpa)")
   <*> switch
       (  long "make-cud"
@@ -132,3 +132,6 @@ configuration = Configuration
       <> metavar "CUD_FILE"
       <> value ""
       <> help "Pass in .cud file to see if ALPACA can chew on a subspace." )
+  <*> switch
+      (  long "docker"
+      <> help "Run portfolio using docker; requires sudo privileges" )

--- a/aca-framework/src/AcaComputation.hs
+++ b/aca-framework/src/AcaComputation.hs
@@ -356,7 +356,13 @@ setupRunConfiguration tag = do
   debugMode <- getDebugMode; exitStrat <- getExitStrategy;
   bValid <- shouldBlockValid; parallelism <- getParallelism
   logPre <- getLogPrefix; exitF <- getExitSummaryFile; dTool <- getDseTool
-  return (RunConfiguration parallelism debugMode tag exitStrat bValid logPre exitF dTool)
+  dockerFlag <- getDockerFlag
+  return (RunConfiguration parallelism debugMode tag exitStrat bValid logPre exitF dTool dockerFlag)
+
+getDockerFlag :: AcaComputation Bool
+getDockerFlag = do
+  st <- get
+  return $ dockerPort st
 
 getDseTool :: AcaComputation DseTool
 getDseTool = do

--- a/aca-framework/src/AcaComputation.hs
+++ b/aca-framework/src/AcaComputation.hs
@@ -35,7 +35,8 @@ data AcaState = AcaState {
   genStrategy    :: GenStrategy,
   dseTool        :: DseTool,
   makeCud        :: Bool,
-  chewCud        :: String
+  chewCud        :: String,
+  dockerPort     :: Bool
   } deriving (Show)
 
 data Program = Program {

--- a/aca-framework/src/Analysis.hs
+++ b/aca-framework/src/Analysis.hs
@@ -7,6 +7,7 @@ import qualified Data.Map.Strict as Map
 import Language.C.Syntax
 import Language.C
 import System.FilePath.Posix
+import System.Posix.User
 import System.Directory
 import System.Process
 import System.Environment (getEnv, setEnv)
@@ -277,6 +278,10 @@ checkFileExists f = do
 
 runAca :: Configuration -> IO Csc
 runAca c@(Configuration program d timeout selection gTimeout bValid ex gex logPre targetFunc partBound merLen genStrat cppFlags iTimeout exclusion dseT mkCud chCud) = do
+  uId <- getRealUserID
+  if uId /= 0
+    then error "user must be root to run docker"
+    else return ()
   checkFileExists program
   setLibraryEnvironmentVariable
   now <- getCurrentTime
@@ -338,8 +343,9 @@ dseChoice s = error $ "sorry, i do not recognize the --dse option '"++s++"'. cho
 
 setLibraryEnvironmentVariable :: IO ()
 setLibraryEnvironmentVariable = do
-  homeDir <- getEnv "HOME"
-  let acaConfig = homeDir ++ "/.aca.config"
+  putStrLn "remember to change hard-coded home on doppios"
+  let hardCodedHome = "/home/mitch"
+  let acaConfig = hardCodedHome ++ "/.aca.config"
   configFileExists <- doesFileExist acaConfig
   if configFileExists
     then do
@@ -348,7 +354,7 @@ setLibraryEnvironmentVariable = do
       setEnv "ACA_LIB" path'
       return ()
     else do
-      putStrLn "Could not find ~/.aca.config. Aborting"
+      putStrLn $ "Could not find "++hardCodedHome++"/.aca.config. Aborting"
       assert False (return ())
 
 debugMode :: String -> DebugMode

--- a/aca-framework/src/Analysis.hs
+++ b/aca-framework/src/Analysis.hs
@@ -343,8 +343,7 @@ dseChoice s = error $ "sorry, i do not recognize the --dse option '"++s++"'. cho
 
 setLibraryEnvironmentVariable :: IO ()
 setLibraryEnvironmentVariable = do
-  putStrLn "remember to change hard-coded home on doppios"
-  let hardCodedHome = "/home/mitch"
+  let hardCodedHome = "/u/mjg6v"
   let acaConfig = hardCodedHome ++ "/.aca.config"
   configFileExists <- doesFileExist acaConfig
   if configFileExists

--- a/aca-framework/src/BinarySearch.hs
+++ b/aca-framework/src/BinarySearch.hs
@@ -63,7 +63,7 @@ bestOverapproximators _ = False
 singletonSearch :: GenStrategy -> AcaComputation GeneralizeResult
 singletonSearch strat = do
   st <- get
-  let (AcaState prog csc pfolio d _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) = st
+  let (AcaState prog csc pfolio d _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) = st
   let smallPfolio = filter bestOverapproximators pfolio
   let debug = ((d == Full) || (d == Generalize))
   if debug then do io $ putStrLn "** Generalizing **" else return ()
@@ -111,7 +111,7 @@ singletonSearch strat = do
 heuristicSearch :: GenStrategy -> AcaComputation GeneralizeResult
 heuristicSearch strat = do
   st <- get
-  let (AcaState prog csc pfolio d _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) = st
+  let (AcaState prog csc pfolio d _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) = st
   let debug = ((d == Full) || (d == Generalize))
   if debug then do io $ putStrLn "** Generalizing **" else return ()
   byPred assert "There is some partition describing reachability"
@@ -197,7 +197,7 @@ heuristicSearch strat = do
 binarySearch :: GenStrategy -> AcaComputation GeneralizeResult
 binarySearch strat = do
   st <- get
-  let (AcaState prog csc pfolio d _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) = st
+  let (AcaState prog csc pfolio d _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) = st
   let debug = ((d == Full) || (d == Generalize))
   if debug then do io $ putStrLn "** Generalizing **" else return ()
   byPred assert "There is some partition describing reachability"

--- a/aca-framework/src/Configuration.hs
+++ b/aca-framework/src/Configuration.hs
@@ -20,6 +20,7 @@ data Configuration = Configuration
   , dseParam :: String
   , makeCudParam :: Bool
   , chewCudParam :: String
+  , dockerParam :: Bool
   } deriving (Show)
 
 data CountConfiguration = CountConfiguration { cscFileToCount :: String }

--- a/aca-framework/src/CscTypes.hs
+++ b/aca-framework/src/CscTypes.hs
@@ -171,7 +171,8 @@ data RunConfiguration = RunConfiguration {
   runBlockValid :: Bool,
   runLogPrefix :: String,
   runExitFile :: FilePath,
-  runDseTool :: DseTool
+  runDseTool :: DseTool,
+  runDocker :: Bool
   }
 
 data DebugMode =

--- a/aca-framework/src/LaunchBenchexec.hs
+++ b/aca-framework/src/LaunchBenchexec.hs
@@ -36,16 +36,20 @@ makeOptions tool = concat $ map makeOption (analysisOptions tool)
 xmlFooter :: String
 xmlFooter = "</benchmark>"
 
-taskToRun :: FilePath -> FilePath -> String
-taskToRun file _ =
+taskToRun :: FilePath -> FilePath -> Bool -> String
+taskToRun file aDir dock =
   let fileName = last $ splitOn "/" file
-      propertyFile = "/PropertyUnreachCall.prp"
+      propertyFile = propFile aDir dock
   in
     "<tasks name=\""++fileName++"\">\n\
     \<include>"++file++"</include>\n\
     \<propertyfile>"++propertyFile++"</propertyfile>\n\
     \</tasks>\n"
 
-constructXML :: Analyzer -> FilePath -> FilePath -> String
-constructXML a f d = (xmlHeader a) ++ (makeOptions a) ++ (taskToRun f d) ++ xmlFooter
+propFile :: FilePath -> Bool -> String
+propFile aDir False = aDir ++ "/PropertyUnreachCall.prp"
+propFile _ True = "/PropertyUnreachCall.prp"
+
+constructXML :: Analyzer -> FilePath -> FilePath -> Bool -> String
+constructXML a f d dock = (xmlHeader a) ++ (makeOptions a) ++ (taskToRun f d dock) ++ xmlFooter
 

--- a/aca-framework/src/LaunchBenchexec.hs
+++ b/aca-framework/src/LaunchBenchexec.hs
@@ -37,9 +37,9 @@ xmlFooter :: String
 xmlFooter = "</benchmark>"
 
 taskToRun :: FilePath -> FilePath -> String
-taskToRun file aDir =
+taskToRun file _ =
   let fileName = last $ splitOn "/" file
-      propertyFile = aDir ++ "/PropertyUnreachCall.prp"
+      propertyFile = "/PropertyUnreachCall.prp"
   in
     "<tasks name=\""++fileName++"\">\n\
     \<include>"++file++"</include>\n\

--- a/aca-framework/src/Portfolio.hs
+++ b/aca-framework/src/Portfolio.hs
@@ -287,4 +287,4 @@ fullPortfolio timeout gTimeout iTimeout = do
       generalizeTimeout = gTimeout,
       initTimeout = iTimeout
       }
-  return [cpaSeq,uAutomizer,esbmc,pesco,symbiotic,veriAbs,twoLs,cbmc,uTaipan,uKojak,cpaBamBnb,pinaka]
+  return [cpaSeq,uAutomizer,esbmc,pesco,symbiotic,veriAbs,twoLs,cbmc,uTaipan,uKojak,pinaka]

--- a/aca-framework/src/Portfolio.hs
+++ b/aca-framework/src/Portfolio.hs
@@ -287,4 +287,15 @@ fullPortfolio timeout gTimeout iTimeout = do
       generalizeTimeout = gTimeout,
       initTimeout = iTimeout
       }
-  return [cpaSeq,uAutomizer,esbmc,pesco,symbiotic,veriAbs,twoLs,cbmc,uTaipan,uKojak,pinaka]
+    seahorn = Analyzer {
+      analysisTool = Seahorn,
+      analysisName = "seahorn",
+      analysisDir = portfolioDir ++ "Seahorn",
+      analysisOptions = [("--cex=witness.graphml", Nothing)],
+      safeOverapproximation = True,
+      analysisTimeout = timeout,
+      witnessType = ConcreteInputs,
+      generalizeTimeout = gTimeout,
+      initTimeout = iTimeout
+      }
+  return [cpaSeq,uAutomizer,esbmc,pesco,symbiotic,veriAbs,twoLs,cbmc,uTaipan,uKojak,pinaka,seahorn]

--- a/aca-framework/src/RunPortfolio.hs
+++ b/aca-framework/src/RunPortfolio.hs
@@ -253,7 +253,7 @@ runBenchexec cFile a timeout oDir mTag debug logPre = do
   let xmlHandle = makeXmlHandle pre oDir a mTag
   writeFile xmlHandle xmlString
 --  _ <- error "stopping for now within runBenchexec..."
-  let containerName = "test"
+  let containerName = "portfolio"
   let args = [(show timeout),
               "docker",
               "run",

--- a/aca-framework/src/RunPortfolio.hs
+++ b/aca-framework/src/RunPortfolio.hs
@@ -724,8 +724,11 @@ programWithinToolDir p a =
 
 checkAnalysisWitness :: DseTool -> DebugMode -> Bool -> FilePath -> AnalysisWitness -> IO PieceOfEvidence
 checkAnalysisWitness _ _ _ _ w@(AnalysisWitness _ _ _ True _ _ _) = return (LegitimateEvidence w emptySubspace 0)
-checkAnalysisWitness CpaSymExec d _ _ witness@(AnalysisWitness tool progPath _ _ _ _ _) = do
+checkAnalysisWitness CpaSymExec d _ _ witness@(AnalysisWitness tool progPath wPath _ _ _ _) = do
   let witness' = witness
+  -- the following hack is to remove docker absolute paths written by Ultimate* tools
+  -- that cause CPA-SymExec to fail when replaying their witness
+  callCommand $ "sed -i '/<data key=\"originfile\">/d' "++wPath
   result <- (guidedSymExec witness' CpaSymExec d False)
   if isJust result
     then do

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:18.04
+
+# Install benchexec
+RUN apt update && apt install -y wget
+RUN wget https://github.com/sosy-lab/benchexec/releases/download/2.7/benchexec_2.7-1_all.deb
+RUN apt install -y --install-recommends ./benchexec_*.deb
+RUN adduser root benchexec
+
+COPY ./download_tools.sh /
+COPY ./PropertyUnreachCall.prp /
+#ENTRYPOINT ["/file.sh"]
+RUN mkdir /home/alpaca_logs
+RUN apt update && apt install -y emacs
+
+RUN ln -s /usr/bin/python2.7 /usr/bin/python
+RUN apt update && apt install -y python2.7
+RUN apt update && apt install -y libc6-dev-i386
+RUN apt update && apt install -y python-pycparser
+RUN apt update && apt install -y libgmp-dev
+RUN apt update && apt install -y zip
+
+RUN /download_tools.sh
+COPY ./run_benchexec.sh /
+RUN apt update && apt install -y openjdk-8-jre
+ENTRYPOINT ["/run_benchexec.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,8 @@ RUN apt update && apt install -y libgmp-dev
 RUN apt update && apt install -y zip
 
 RUN /download_tools.sh
-COPY ./run_benchexec.sh /
 RUN apt update && apt install -y openjdk-8-jre
+RUN mkdir /home/benchexec
+RUN apt update && apt install -y perl
+COPY ./run_benchexec.sh /
 ENTRYPOINT ["/run_benchexec.sh"]

--- a/docker/PropertyUnreachCall.prp
+++ b/docker/PropertyUnreachCall.prp
@@ -1,0 +1,1 @@
+CHECK( init(main()), LTL(G ! call(__VERIFIER_error())) )

--- a/docker/download_tools.sh
+++ b/docker/download_tools.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+function check_for {
+    command -v $1 >/dev/null 2>&1 || { echo >&2 "I require $1 but it's not installed.  Aborting."; exit 1; }
+}
+
+function check_for_python_3_6 {
+    command -v "python3.6" >/dev/null 2>&1 || { echo >&2 "Please create a symbolic link from python3.6 to your version of python3 (e.g., 3.8) with the command 'sudo ln -s /usr/bin/python3.8 /usr/bin/python3.6'.  Some tools in the portfolio look explicitly for python3.6, unfortunately. Aborting."; exit 1; }
+}
+
+function check_for_python {
+    command -v "python" >/dev/null 2>&1 || { echo >&2 "Please create a symbolic link from python to your version of python2 (e.g., 2.7) with the command 'sudo ln -s /usr/bin/python2.7 /usr/bin/python'.  Some tools in the portfolio have a wrapper script that uses constructs only legal in python 2, unfortunately. Aborting."; exit 1; }
+}
+
+verlte() {
+    [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+}
+
+verlt() {
+    [ "$1" = "$2" ] && return 1 || verlte $1 $2
+}
+
+function check_java_version {
+    java_version=$(java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}')
+    verlt $java_version 11 && {
+	echo "Please install Java 11; this version is required by CPA's symbolic executor.";
+	exit 1;
+    }
+}
+
+function check_benchexec_version {
+    benchexec_version=$(benchexec --version | awk '{print $2}')
+    verlt $benchexec_version 2.7 && {
+	echo "Please update your version of benchexec to at least 2.7 by downloading the latest .deb file listed at github.com/mgerrard/alpaca/README.md and following the install instructions.";
+	exit 1;
+    }
+}
+
+function does_package_exist {
+    dpkg -l $1 >/dev/null 2>&1 || { echo >&2 "I cannot find $1 in your package manager; please install it. Aborting."; exit 1; }
+}
+
+check_java_version
+check_for "python3"
+check_for_python_3_6
+check_for_python
+check_for "benchexec"
+check_benchexec_version
+does_package_exist "libc6-dev-i386"
+does_package_exist "python-pycparser"
+does_package_exist "libgmp-dev"
+
+function unpack_and_rename_zip_if_needed {
+    # first: canonical folder name (e.g., CPA_Seq)
+    # second: zip file name (e.g., cpa-seq)
+    # third: unpacked folder name (e.g., CPAchecker-1.6.23-svn\ 26773-unix)
+    if [ ! -d "$1" ]; then
+	echo "-> unpacking $1"
+	if [[ $1 == "InterpChecker" ]] || [[ $1 == "VeriAbs" ]]; then
+	    unzip -q $2.zip
+        else
+	    unzip -q $2.zip && mv "$3" $1;
+	fi
+    fi
+}
+
+ARCHIVE_REPO="https://gitlab.com/sosy-lab/sv-comp/archives-2020/raw/svcomp20/2020"
+
+function download_zip_if_needed {
+
+    zip_file="$1.zip"
+    expected_size="$2"
+    unpacked_name="$3"
+    download_link="$ARCHIVE_REPO/$zip_file"
+     
+    if [ ! -f "$zip_file" ]; then
+	echo "i didnt find $zip_file in $SV_ARCHIVES"
+	echo "downloading it from $download_link"
+	wget $download_link
+    else
+	actual_size=$(stat -c %s "$zip_file")
+        if [ $actual_size -eq $expected_size ]; then
+	    echo "you have the latest $zip_file, moving on..."
+	else
+	    echo "removing stale $zip_file"
+	    rm -f $zip_file
+	    echo "removing possible stale unpacked folder"
+	    rm -rf $unpacked_name
+
+	    echo "downloading new $zip_file from $download_link"
+       	    wget $download_link	    
+	fi
+    fi
+}
+
+echo
+echo "Downloading SVCOMP archives"
+echo
+
+download_zip_if_needed "cpa-seq" "102733640" "CPA_Seq"
+download_zip_if_needed "uautomizer" "84313069" "UAutomizer"
+download_zip_if_needed "symbiotic" "73653236" "Symbiotic"
+download_zip_if_needed "esbmc" "39176877" "ESBMC"
+download_zip_if_needed "pesco" "289247537" "Pesco"
+download_zip_if_needed "veriabs" "313055755" "VeriAbs"
+download_zip_if_needed "2ls" "3983396" "TwoLS"
+download_zip_if_needed "cbmc" "6832746" "CBMC"
+download_zip_if_needed "utaipan" "84306647" "UTaipan"
+download_zip_if_needed "ukojak" "84301613" "UKojak"
+download_zip_if_needed "cpa-bam-bnb" "101242097" "CPA_BAM_BnB"
+download_zip_if_needed "pinaka" "50696530" "Pinaka"
+
+echo
+echo "Unpacking any zipped SVCOMP archives"
+
+unpack_and_rename_zip_if_needed "CPA_Seq" "cpa-seq" "CPAchecker-1.9-unix"
+unpack_and_rename_zip_if_needed "UAutomizer" "uautomizer" "UAutomizer-linux"
+unpack_and_rename_zip_if_needed "Symbiotic" "symbiotic" "symbiotic"
+unpack_and_rename_zip_if_needed "ESBMC" "esbmc" "esbmc"
+unpack_and_rename_zip_if_needed "Pesco" "pesco" "PeSCo-1.8.2"
+unpack_and_rename_zip_if_needed "VeriAbs" "veriabs"
+unpack_and_rename_zip_if_needed "TwoLS" "2ls" "2ls"
+unpack_and_rename_zip_if_needed "CBMC" "cbmc" "cbmc"
+unpack_and_rename_zip_if_needed "UTaipan" "utaipan" "UTaipan-linux"
+unpack_and_rename_zip_if_needed "UKojak" "ukojak" "UKojak-linux"
+unpack_and_rename_zip_if_needed "CPA_BAM_BnB" "cpa-bam-bnb" "cpa-bam-bnb"
+unpack_and_rename_zip_if_needed "Pinaka" "pinaka" "pinaka"

--- a/docker/run_benchexec.sh
+++ b/docker/run_benchexec.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# MAKE SURE MOUNTED DIRECTORY IS WRITEABLE
+MOUNTED_DIR=/home/alpaca_logs
+# 1. find the $XML_FILE at $MOUNTED_DIR
+XML_FILE=( $MOUNTED_DIR/*.xml )
+# 2. infer the $TOOL from the $XML_FILE
+TOOL=`basename $XML_FILE .xml`
+# 3. go to that $TOOL's directory
+cd $TOOL
+# 4. run benchexec from the $XML_FILE
+benchexec --full-access-dir / $XML_FILE
+# 5. if witness exists, move it to the results directory
+WITNESS=`find . -name "*.graphml"`
+if [ -n "$WITNESS" ]; then mv $WITNESS results; fi
+# 6. move the results directory to the mounted directory
+mv results $MOUNTED_DIR

--- a/docker/run_benchexec.sh
+++ b/docker/run_benchexec.sh
@@ -11,7 +11,7 @@ cd $TOOL
 # 4. run benchexec from the $XML_FILE
 benchexec --full-access-dir / $XML_FILE
 # 5. if witness exists, move it to the results directory
-WITNESS=`find . -name "*.graphml"`
-if [ -n "$WITNESS" ]; then mv $WITNESS results; fi
+WITNESS=`find . -name "*witness.graphml"`
+if [ -n "$WITNESS" ]; then cp --no-preserve=mode $WITNESS results; fi
 # 6. move the results directory to the mounted directory
-mv results $MOUNTED_DIR
+cp --no-preserve=mode -r results $MOUNTED_DIR

--- a/docker/seahorn/run_seahorn.sh
+++ b/docker/seahorn/run_seahorn.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /host
+sea pf -m64 *.c

--- a/docker/seahorn/seahorn-full-size-rel.Dockerfile
+++ b/docker/seahorn/seahorn-full-size-rel.Dockerfile
@@ -1,0 +1,55 @@
+#
+# Dockerfile for SeaHorn binary
+# produces package in /seahorn/build
+# Arguments:
+#  - UBUNTU:     trusty, xenial, bionic
+#  - BUILD_TYPE: debug, release
+#  - TRAVIS:     true (optional, for use on Travis only)
+#
+
+ARG UBUNTU
+
+# Pull base image.
+FROM seahorn/seahorn-build-llvm5:$UBUNTU
+
+ARG TRAVIS
+
+# clone SeaHorn (just copy on Travis)
+# since there are no conditionals in docker,
+# always copy, and, if needed, remove and clone instead
+COPY . /seahorn
+RUN if [ "$TRAVIS" != "true" ] ; \
+      then cd / && rm -rf /seahorn && git clone https://github.com/seahorn/seahorn --depth=10 ; \
+    fi && \
+    mkdir -p /seahorn/build
+WORKDIR /seahorn/build
+
+ARG BUILD_TYPE
+# Build configuration.
+RUN cmake -GNinja \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DBOOST_ROOT=/deps/boost \
+          -DZ3_ROOT=/deps/z3 \
+          -DYICES2_HOME=/deps/yices-2.6.1 \
+          -DLLVM_DIR=/deps/LLVM-5.0.2-Linux/lib/cmake/llvm \
+          -DCMAKE_INSTALL_PREFIX=run \
+          -DCMAKE_CXX_COMPILER=g++-5 \
+          -DCPACK_GENERATOR="TGZ" \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
+          ../ && \
+    cmake --build . --target extra  && cmake .. && \
+    cmake --build . --target crab  && cmake .. && \
+    cmake --build . --target install && \
+    cmake --build . --target units_z3 && \
+    cmake --build . --target units_yices2 && \
+    cmake --build . --target package && \
+    # symlink clang (from base image)
+    ln -s /clang-5.0/bin/clang run/bin/clang && \
+    ln -s /clang-5.0/bin/clang++ run/bin/clang++ && \
+    if [ "$TRAVIS" = "true" ] ; \
+      then units/units_z3 && units/units_yices2 ; \
+    fi
+
+ENV PATH "/seahorn/build/run/bin:$PATH"
+
+WORKDIR /seahorn

--- a/docker/seahorn/seahorn.Dockerfile
+++ b/docker/seahorn/seahorn.Dockerfile
@@ -1,0 +1,67 @@
+#
+# Minimal Dockerfile for SeaHorn
+# produces a lightweight container with SeaHorn
+# Arguments:
+#  - BASE_IMAGE: seahorn/seahorn (for use on Travis only), buildpack-deps (default)
+#
+
+ARG BASE_IMAGE=ubuntu:16.04
+FROM $BASE_IMAGE
+
+ARG BASE_IMAGE=ubuntu:16.04
+ENV SEAHORN=/opt/seahorn/bin/sea PATH="$PATH:/opt/seahorn/bin:/opt/llvm/bin"
+USER root
+
+RUN if [ "$BASE_IMAGE" != "seahorn/seahorn-llvm5" ] && [ "$BASE_IMAGE" != "ubuntu:16.04" ] ; \
+      then exit -1 ; \
+      else echo "pulling from $BASE_IMAGE" ; \
+    fi && \
+    rm -rf /opt && \
+    mkdir -p /opt
+COPY *.tar.gz /opt
+WORKDIR /opt
+
+# extract seahorn
+RUN mkdir -p seahorn && \
+    tar -xf *.tar.gz -C seahorn --strip-components=1 && \
+    rm -f *.tar.gz && \
+    if [ "$BASE_IMAGE" != "seahorn/seahorn-llvm5" ] ; \
+      then \
+        # install test dependencies & tools
+        apt-get update && \
+        apt-get install --no-install-recommends -yqq \
+            sudo curl build-essential vim-tiny gdb \
+            python-dev python-setuptools python-pip libgraphviz-dev libc6-dev-i386 && \
+        pip install --upgrade pip && \
+        python -m pip install setuptools --upgrade && \
+        python -m pip install lit OutputCheck && \
+        python -m pip install networkx==2.2 pygraphviz && \
+        # get supported llvm version
+        mkdir /opt/llvm && \
+        curl -sL https://github.com/seahorn/seahorn-ext-deps/releases/download/5.0-deep-dev/xenial_rel_llvm50.tar.gz \
+        | tar -xzf - -C /opt/llvm --strip-components=1 && \
+        # download clang
+        mkdir /clang-5.0 && \
+        curl -s https://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu16.04.tar.xz \
+        | tar -xJf - -C /clang-5.0 --strip-components=1 && \
+        apt-get remove -yqq curl && \
+        rm -rf /var/lib/apt/lists/* && \
+        # set up default user
+        useradd -ms /bin/bash usea && \
+        echo usea:horn | chpasswd && \
+        usermod -aG sudo usea ; \
+    fi && \
+    # symlink clang
+    cd seahorn/bin && \
+    ln -s /clang-5.0/bin/clang clang && \
+    ln -s /clang-5.0/bin/clang++ clang++ && \
+    # finish setting up permissions
+    chmod -R 777 /opt/seahorn && \
+    # make the environment more pleasant to use
+    ln -sfn /usr/bin/vim.tiny /usr/bin/vim && \
+    echo "PS1='\${debian_chroot:+(\$debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\n\[\033[00m\]\\\$ '" >> /home/usea/.bashrc
+
+WORKDIR seahorn
+USER usea
+COPY ./run_seahorn.sh /
+ENTRYPOINT ["/run_seahorn.sh"]


### PR DESCRIPTION
Merging doppio branch into main, which:
  - adds the --docker switch, which will run benchexec within multiple container instances (this was added to be able to run on a non-Ubuntu-based OS; it unfortunately requires sudo permissions for each run of ALPACA)
  - reverts the default symbolic execution engine to be CIVL
  - adds SeaHorn to portfolio
  